### PR TITLE
feat: add depends_on to compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - "7777:7777"
     networks:
       - petio-network
+    depends_on:
+      - mongo
     user: "1000:1000"
     environment:
       - TZ=Etc/UTC


### PR DESCRIPTION
This adds the `depends_on` configuration to the petio service so that mongodb is sure to be up and running when the user goes through the setup process