### PR TITLE
Add toggle for showing popular content on plex

### DIFF
--- a/admin/src/page/settings/general.js
+++ b/admin/src/page/settings/general.js
@@ -17,6 +17,7 @@ class General extends React.Component {
       base_path: "",
       login_type: false,
       discord_webhook: false,
+      plex_popular: true,
     };
 
     this.inputChange = this.inputChange.bind(this);
@@ -27,6 +28,7 @@ class General extends React.Component {
     this.saveBasePath = this.saveBasePath.bind(this);
     this.saveDiscord = this.saveDiscord.bind(this);
     this.saveLoginType = this.saveLoginType.bind(this);
+    this.savePlexPopular = this.savePlexPopular.bind(this);
     this.testDiscord = this.testDiscord.bind(this);
   }
 
@@ -120,6 +122,24 @@ class General extends React.Component {
     }
   }
 
+  async savePlexPopular() {
+    try {
+      await Api.updateConfig({
+        plex_popular: this.state.plex_popular,
+      });
+      this.props.msg({
+        message: "Plex Popular Saved",
+        type: "good",
+      });
+    } catch (err) {
+      console.log(err);
+      this.props.msg({
+        message: "Failed to Save Plex Popular",
+        type: "error",
+      });
+    }
+  }
+
   async loadConfigs() {
     try {
       let email = await Api.getEmailConfig();
@@ -135,6 +155,7 @@ class General extends React.Component {
         base_path: config.base_path ? config.base_path : "",
         login_type: config.login_type ? config.login_type : 1,
         discord_webhook: config.discord_webhook ? config.discord_webhook : "",
+        plex_popular: config.plex_popular,
         loading: false,
       });
       this.props.msg({
@@ -411,6 +432,23 @@ class General extends React.Component {
             onClick={this.testDiscord}
           >
             Test
+          </button>
+        </section>
+        <section>
+          <p className="main-title mb--2">Popular content on Plex</p>
+          <p className="description">
+            Adds a section to Movies and TV Shows showing the current most popular content on Plex.
+          </p>
+          <div className="checkbox-wrap mb--2">
+            <input
+              type="checkbox"
+              name="plex_popular"
+              checked={this.state.plex_popular}
+              onChange={this.inputChange}
+            />
+          </div>
+          <button className="btn btn__square" onClick={this.savePlexPopular}>
+            Save
           </button>
         </section>
       </>

--- a/api/app.js
+++ b/api/app.js
@@ -77,6 +77,34 @@ class Main {
       this.e.use(express.urlencoded({ extended: true }));
     }
     this.config = getConfig();
+
+    if (typeof this.config.plex_popular == 'undefined') {
+      this.updatePopularConfig()
+    }
+  }
+
+  async updatePopularConfig() {
+    let project_folder, configFile;
+    if (process.pkg) {
+      project_folder = path.dirname(process.execPath);
+      configFile = path.join(project_folder, "./config/config.json");
+    } else {
+      project_folder = __dirname;
+      configFile = path.join(project_folder, "./config/config.json");
+    }
+    try {
+      let updatedConfig = JSON.stringify({ ...this.config, plex_popular: true });
+      fs.writeFile(configFile, updatedConfig, (err) => {
+        if (err) {
+          logger.log("warn", err);
+        } else {
+          logger.log("info", 'Config updated with plex_popular variable');
+        }
+      });
+    } catch (err) {
+      logger.log("verbose", err);
+      logger.log("warn", 'Config not found');
+    }
   }
 
   setRoutes() {
@@ -307,6 +335,7 @@ class Main {
         adminDisplayName: user.username,
         fanartApi: "ee409f6fb0c5cd2352e7a454d3f580d4",
         base_path: "",
+        plex_popular: true,
       };
       try {
         await this.createConfig(JSON.stringify(configData, null, 2));

--- a/api/discovery/display.js
+++ b/api/discovery/display.js
@@ -18,10 +18,13 @@ const memoryCache = cacheManager.caching({
 module.exports = async function getDiscoveryData(id, type = "movie") {
   if (!id) throw "No user";
   const discoveryPrefs = await Discovery.findOne({ id: id });
-  const popularData = await getTop(type === "movie" ? 1 : 2);
+  const config = getConfig();
   let popular = [];
-  for (p in popularData) {
-    popular.push(popularData[p]);
+  if (config.plex_popular) {
+    const popularData = await getTop(type === "movie" ? 1 : 2);
+    for (p in popularData) {
+      popular.push(popularData[p]);
+    }
   }
   if (!discoveryPrefs) throw "No user profile created";
   const watchHistory =
@@ -241,7 +244,7 @@ module.exports = async function getDiscoveryData(id, type = "movie") {
         });
   let data = [...peopleData, ...directorData, ...recentData, ...genresData];
   data = shuffle(data);
-  return [
+  return config.plex_popular ? [
     {
       title:
         type === "movie" ? "Popular Movies on Plex" : "Popular Shows on Plex",
@@ -252,7 +255,13 @@ module.exports = async function getDiscoveryData(id, type = "movie") {
       results: upcoming.results,
     },
     ...data,
-  ];
+  ] : [
+      {
+        title: type === "movie" ? "Movies coming soon" : "Shows coming soon",
+        results: upcoming.results,
+      },
+      ...data,
+    ];
 };
 
 // Caching layer


### PR DESCRIPTION
Allows you to toggle the "Popular Shows/Movies On Plex" section on the content discovery pages. 

By default it's enabled, a checkbox has been added to the bottom of the general settings to change the value. Alternatively changing the "plex_popular" boolean in the config file.

<img src="https://user-images.githubusercontent.com/2633890/111876193-81751b00-8995-11eb-8913-6e893227b299.png" width="700" height="250">

On startup it will check the current config.json to see if it has the "plex_popular" variable, if not it will add the variable with the default value (true)

Let me know if there are any mistakes, I'll admit I'm not too great with JS haha.