### PR TITLE
Check if config exists before trying to add plex_popular to it

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -78,7 +78,7 @@ class Main {
     }
     this.config = getConfig();
 
-    if (typeof this.config.plex_popular == 'undefined') {
+    if (typeof this.config.plex_popular == 'undefined' && this.config) {
       this.updatePopularConfig()
     }
   }


### PR DESCRIPTION
Previously it tried to update the config when it didn't exist, meaning it could create a config before setup occurs. 
Setup doesn't like that a config exists so it'll error out. A simple check to make sure that doesn't happen.