### PR TITLE
make petio docker images multi-arch-compatible

### DIFF
--- a/.github/workflows/docker-master.yml
+++ b/.github/workflows/docker-master.yml
@@ -10,9 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build Docker image
-        run: docker build -t ghcr.io/${{ github.repository }}:latest -t ghcr.io/${{ github.repository }}:latest-${GITHUB_SHA::8} .
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v1.2.0
       - name: Docker login
         run: echo ${{ secrets.GHCR_TOKEN }} | docker login -u ${{ github.repository_owner }} --password-stdin ghcr.io
-      - name: Push docker image
-        run: docker push ghcr.io/${{ github.repository }}:latest
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:latest-${GITHUB_SHA::8}

--- a/.github/workflows/docker-preview.yml
+++ b/.github/workflows/docker-preview.yml
@@ -10,9 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build Docker image
-        run: docker build -t ghcr.io/${{ github.repository }}:preview -t ghcr.io/${{ github.repository }}:preview-${GITHUB_SHA::8} .
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v1.2.0
       - name: Docker login
         run: echo ${{ secrets.GHCR_TOKEN }} | docker login -u ${{ github.repository_owner }} --password-stdin ghcr.io
-      - name: Push docker image
-        run: docker push ghcr.io/${{ github.repository }}:preview
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: ghcr.io/${{ github.repository }}:preview,ghcr.io/${{ github.repository }}:preview-${GITHUB_SHA::8}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,9 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build Docker image
-        run: docker build -t ghcr.io/${{ github.repository }}:dev -t ghcr.io/${{ github.repository }}:dev-${GITHUB_SHA::8} .
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v1.2.0
       - name: Docker login
         run: echo ${{ secrets.GHCR_TOKEN }} | docker login -u ${{ github.repository_owner }} --password-stdin ghcr.io
-      - name: Push docker image
-        run: docker push ghcr.io/${{ github.repository }}:dev
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: ghcr.io/${{ github.repository }}:dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM --platform=linux/amd64 node:14.15.1-alpine3.12 as builder
+FROM node:14.15.1-alpine3.12 as builder
 
-RUN apk add --no-cache git
+RUN apk add --no-cache git python3 build-base
 COPY ./ /source/
 RUN mkdir /build && \
     cp /source/petio.js /build/ && \


### PR DESCRIPTION
This patch changes workflows and `Dockerfile` to create mulit-arch compatible docker images. 
Using buildx we are able to create compatible images for these platforms:

- linux/amd64
- linux/arm64
- linux/arm/v7