### PR TITLE
Add dedicated health endpoint and update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ LABEL org.opencontainers.image.vendor="petio-team"
 LABEL org.opencontainers.image.url="https://github.com/petio-team/petio"
 LABEL org.opencontainers.image.documentation="https://github.com/petio-team/petio-docs/wiki"
 LABEL org.opencontainers.image.licenses="MIT"
-HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "wget", "--spider", "http://localhost:7777" ]
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "wget", "--spider", "http://localhost:7777/health" ]

--- a/petio.js
+++ b/petio.js
@@ -63,6 +63,7 @@ class Wrapper {
         process.exit(1);
       });
       try {
+        app.get('/health', (_, res) => res.status(200).send('OK'))
         let basePath = await this.getBase();
         logger.log("info", `ROUTER: Base path found - ${basePath}`);
         app.use((req, res, next) => {


### PR DESCRIPTION
Adds a dedicated health endpoint `/health` that works regardless of the base path that is set. 

Closes #419 