### PR TITLE
Fixed trailers not showing up

### DIFF
--- a/frontend/src/components/MovieShowTop.js
+++ b/frontend/src/components/MovieShowTop.js
@@ -5,7 +5,7 @@ import { ReactComponent as CheckIcon } from "../assets/svg/check.svg";
 import { ReactComponent as Spinner } from "../assets/svg/spinner.svg";
 import { ReactComponent as CloseIcon } from "../assets/svg/close.svg";
 import { LazyLoadImage } from "react-lazy-load-image-component";
-import ReactPlayer from "react-player";
+import ReactPlayer from "react-player/youtube";
 
 class MovieShowTop extends React.Component {
   constructor(props) {


### PR DESCRIPTION
Fixes a known issue with trailers not showing up, this is due to a change in an upstream library that requires changing how we import it for use with YouTube.