### PR TITLE
Prevent grabbing specials when an entire series is requested

### DIFF
--- a/frontend/src/pages/Series.js
+++ b/frontend/src/pages/Series.js
@@ -145,7 +145,11 @@ class Series extends React.Component {
     let seasons = {};
     if (series.seasons.length > 0)
       series.seasons.map((season) => {
-        seasons[season.season_number] = true;
+        if (season.season_number == 0) {
+          seasons[season.season_number] = false;
+        } else {
+          seasons[season.season_number] = true;
+        }
       });
     let request = {
       id: series.id,


### PR DESCRIPTION
This PR prevents a series request from also requesting special episodes. The requester can still grab them individually.

Fixes: https://github.com/petio-team/petio/issues/471