### PR TITLE
chore(build): pin mongodb docker image at v4.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ networks:
 services:
   petio:
     image: ghcr.io/petio-team/petio:latest
-    container_name: "petio"
+    container_name: petio
     hostname: petio
     ports:
       - "7777:7777"
@@ -23,8 +23,8 @@ services:
       - ./logs:/app/logs
 
   mongo:
-    image: mongo:latest
-    container_name: "mongo"
+    image: mongo:4.4
+    container_name: mongo
     hostname: mongo
     ports:
       - "27017:27017"


### PR DESCRIPTION
A few users have been having issues with MongoDB v5. Pining the mongodb docker image to a known good version would keep further issues from propping up until we can figure what exactly is causing issues with mongodb v5.

List of supported tags for mongodb: [link](https://github.com/docker-library/docs/blob/master/mongo/README.md#supported-tags-and-respective-dockerfile-links)