### PR TITLE
Fixed sonarr logo from deprecated branch to master

### DIFF
--- a/admin/src/page/Settings.js
+++ b/admin/src/page/Settings.js
@@ -72,7 +72,7 @@ class Settings extends React.Component {
             <div className="icon">
               <img
                 className=""
-                src="https://raw.githubusercontent.com/Sonarr/Sonarr/phantom-develop/Logo/256.png"
+                src="https://raw.githubusercontent.com/Sonarr/Sonarr/master/Logo/256.png"
               />
             </div>
           </Link>


### PR DESCRIPTION
Sonarr logo within "Requests" page was pointing to a png from a branch that no longer exists.
This updates the branch to master which correctly resolves the expected logo png