### PR TITLE
fix(api): avoid sending requests to disabled Sonarr servers

### DIFF
--- a/api/services/sonarr.js
+++ b/api/services/sonarr.js
@@ -212,9 +212,13 @@ class Sonarr {
     let servers = this.fullConfig;
     if (server) {
       servers = [this.findUuid(server.id, this.fullConfig)];
+    } else {
+      servers = this.fullConfig.filter(s => s.active);
     }
+
     for (let i = 0; i < servers.length; i++) {
       this.config = servers[i];
+
       let lookup = await this.lookup(request.tvdb_id);
       let showData = lookup[0];
       let rSeasons = request.seasons;


### PR DESCRIPTION
~This is a blind PR, I will test when I figure out how / have time to build my own image.~ Tested and seems to work in both cases.

In my testing, when you have multiple Sonarr servers the requests will get sent to every single one when no filter matches. This doesn't happen with Radarr servers.
This filters out disabled servers so I can have the disabled server used exclusively in filters, without getting all the other requests.

How to reproduce the issue:

1. Add 2 Sonarr servers
2. Disable one of them and optionally set a filter for it.
3. Request a show that matches no filters.
4. It should be added to only the enabled server, without this change it gets added to both. 